### PR TITLE
Support OPTIONS method for checking health

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -54,6 +54,14 @@ class Whazzup < Sinatra::Base
   end
 
   get '/xdb' do
+    check_xdb
+  end
+
+  options '/xdb' do
+    check_xdb
+  end
+
+  def check_xdb
     checker = xdb_checker
 
     if checker.check

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -69,4 +69,9 @@ describe 'Galera health check' do
     get '/xdb'
     expect(last_response.status).to be(503)
   end
+
+  it 'should support the OPTIONS method for checking health (HAProxy default method)' do
+    options '/xdb'
+    expect(last_response.status).to be(200)
+  end
 end


### PR DESCRIPTION
HAProxy uses OPTIONS for its HTTP based health checks. It's easy enough to
teach whazzup to support that default rather than needing to specially
configure HAProxy. GET is also supported.
