### PR TITLE
[DR-41] Fix race condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'sinatra', '~> 1.4.5'
 gem 'puma'
 
 gem 'dogstatsd-ruby', '~> 1.4.1'
+gem 'activesupport'
 
 gem 'rspec', groups: [:development, :test]
 gem 'rack-test', groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.1.1)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
     addressable (2.3.6)
     backports (3.6.0)
     coderay (1.1.0)
@@ -21,10 +27,12 @@ GEM
       net-http-persistent (>= 2.7)
       net-http-pipeline
     highline (1.6.21)
+    i18n (0.6.11)
     json (1.8.1)
     launchy (2.4.2)
       addressable (~> 2.3)
     method_source (0.8.2)
+    minitest (5.4.0)
     multi_json (1.10.1)
     multipart-post (2.0.0)
     mysql2 (0.3.16)
@@ -62,6 +70,7 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.5.0)
+    thread_safe (0.3.4)
     tilt (1.4.1)
     timecop (0.7.1)
     travis (1.7.1)
@@ -77,12 +86,15 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     typhoeus (0.6.9)
       ethon (>= 0.7.1)
+    tzinfo (1.2.1)
+      thread_safe (~> 0.1)
     websocket (1.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   dogstatsd-ruby (~> 1.4.1)
   mysql2 (~> 0.3.16)
   pry

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -8,18 +8,31 @@ describe 'Galera health check' do
   include Rack::Test::Methods
 
   def app
-    Whazzup
+    Whazzup.new
   end
 
   def db_client
-    @db_client ||= Mysql2::Client.new(app.connection_settings)
+    @db_client ||= Mysql2::Client.new(Whazzup.connection_settings)
   end
 
   before do
-    app.set(:wsrep_state_dir, 'spec/data/3_node_cluster_synced')
-    app.set(:hostname, 'test.local')
+    Whazzup.set(:wsrep_state_dir, 'spec/data/3_node_cluster_synced')
+    Whazzup.set(:hostname, 'test.local')
+  end
 
-    app.settings.checkers.clear
+  it 'should require and initialize checkers, and make a first check' do
+    Whazzup.set(:services, [:xdb])
+    expect_any_instance_of(Whazzup).to receive(:require_relative).with 'lib/galera_health_checker'
+
+    service_checker_class = double
+    expect(Whazzup::SERVICE_CHECKERS[:xdb]).to receive(:constantize) { service_checker_class }
+    expect(service_checker_class).to receive(:new)
+
+    health_checker = double
+    expect(HealthChecker).to receive(:new).once { health_checker }
+    expect(health_checker).to receive(:check).once
+
+    app
   end
 
   it 'should be marked up if it is a a synced node' do
@@ -28,19 +41,19 @@ describe 'Galera health check' do
   end
 
   it 'should be marked down if it is a donor node' do
-    app.set(:wsrep_state_dir, 'spec/data/3_node_cluster_donor')
+    Whazzup.set(:wsrep_state_dir, 'spec/data/3_node_cluster_donor')
     get '/xdb'
     expect(last_response.status).to be(503)
   end
 
   it 'should be marked up if it is a donor node in a 2 node cluster' do
-    app.set(:wsrep_state_dir, 'spec/data/2_node_cluster_donor')
+    Whazzup.set(:wsrep_state_dir, 'spec/data/2_node_cluster_donor')
     get '/xdb'
     expect(last_response.status).to be(200)
   end
 
   it 'should be marked down if the wsrep state files cannot be read' do
-    app.set(:wsrep_state_dir, 'does/not/exist')
+    Whazzup.set(:wsrep_state_dir, 'does/not/exist')
     get '/xdb'
     expect(last_response.status).to be(503)
   end
@@ -57,14 +70,14 @@ describe 'Galera health check' do
   end
 
   it 'should be marked down if no row is found for the desired host in the DB' do
-    app.set(:hostname, 'does.not.exist')
+    Whazzup.set(:hostname, 'does.not.exist')
 
     get '/xdb'
     expect(last_response.status).to be(503)
   end
 
   it 'should be marked down if there is trouble connecting to the database' do
-    expect_any_instance_of(Mysql2::Client).to receive(:query).and_raise(Mysql2::Error, 'mocking connection failure')
+    allow_any_instance_of(Mysql2::Client).to receive(:query).and_raise(Mysql2::Error, 'mocking connection failure')
 
     get '/xdb'
     expect(last_response.status).to be(503)


### PR DESCRIPTION
Adds specification of service checkers to chef managed config.

Initializes the configured set of service checkers, which will seed the check data and kick off the monitoring process.

If we really wanted to get crazy we could define routes and checker-getter methods only for what is in `config['services']`

concerns: Is the `activesupport` dependency too much for this?

depends on https://github.com/PagerDuty/chef/pull/2393
