### PR TITLE
503 on /zk/monit_should_restart when wedged

### DIFF
--- a/lib/checkers/zookeeper_health_checker.rb
+++ b/lib/checkers/zookeeper_health_checker.rb
@@ -30,10 +30,10 @@ class ZookeeperHealthChecker
 
     # Failed to get any zk data so bail out
     if srvr_data.nil?
-      @check_details = {'available' => false}
+      @check_details = {'available' => false, 'monit_should_restart' => true}
       return false
     elsif ruok_data.nil?
-      @check_details = {'available' => true, 'ruok' => false}
+      @check_details = {'available' => true, 'ruok' => false, 'monit_should_restart' => true}
       return false
     end
 
@@ -50,6 +50,8 @@ class ZookeeperHealthChecker
                                                     "Wedged: #{check_details['wedged']}\n"
 
     check_details['available'] = true
+
+    check_details['monit_should_restart'] = check_details['wedged']
 
     @check_details = check_details
 

--- a/routes/zk.rb
+++ b/routes/zk.rb
@@ -16,7 +16,7 @@ module Sinatra
           statsd.time('whazzup.zk.monit_should_restart') do
             checker = settings.checkers[:zk]
 
-            if checker.check && !checker.check_details['wedged']
+            if checker.check_details && !checker.check_details['monit_should_restart']
               [200, checker.check_details['monit_should_restart_details']]
             else
               [503, JSON.generate(checker.check_details)]

--- a/spec/app_zk_spec.rb
+++ b/spec/app_zk_spec.rb
@@ -15,10 +15,6 @@ describe 'Zookeeper health check' do
     Whazzup.set(:hostname, 'test.local')
   end
 
-  let(:monit_should_restart_good) { "Leader: true\nruok: imok\nOverOutstandingThreshold: false\nWedged: false\n" }
-
-  let(:monit_should_restart_wedged) { "Leader: true\nruok: imok\nOverOutstandingThreshold: true\nWedged: true\n" }
-
   it 'should require and initialize checkers, and make a first check' do
     Whazzup.set(:services, [:zk])
     expect_any_instance_of(Whazzup).to receive(:require_relative).with 'lib/checkers/zookeeper_health_checker'
@@ -51,11 +47,17 @@ describe 'Zookeeper health check' do
 
   it 'should return monit_should_restart data if it is a good node' do
     get '/zk/monit_should_restart'
-    expect(last_response.body).to eq(monit_should_restart_good)
+    expect(last_response.status).to be(200)
   end
 
   it 'should return 503 on monit_should_restart if node is wedged' do
     Whazzup.set(:zk_outstanding_threshold, -1)
+    get '/zk/monit_should_restart'
+    expect(last_response.status).to be(503)
+  end
+
+  it 'should return 503 on monit_should_restart if whazzup can\'t connect to zk' do
+    allow_any_instance_of(ZookeeperHealthChecker).to receive(:connect).and_raise(IOError, 'mocking connection timeout')
     get '/zk/monit_should_restart'
     expect(last_response.status).to be(503)
   end


### PR DESCRIPTION
Monit 5.6 only can check for a response w/ status 200.  This changes the route so that it only returns a 200 if the zk node is available and not wedged,
