### PR TITLE
Beef up zk data parsing

### DIFF
--- a/lib/checkers/zookeeper_health_checker.rb
+++ b/lib/checkers/zookeeper_health_checker.rb
@@ -68,9 +68,6 @@ class ZookeeperHealthChecker
 
   def parse_srvr_data(data)
     result = {}
-
-    return nil unless data.is_a?(Array)
-
     data.each do |l|
       k,v = l.split(': ')
       next if v.nil?

--- a/lib/checkers/zookeeper_health_checker.rb
+++ b/lib/checkers/zookeeper_health_checker.rb
@@ -62,6 +62,9 @@ class ZookeeperHealthChecker
 
   def parse_srvr_data(data)
     result = {}
+
+    return nil unless data.is_a?(Array)
+
     data.each do |l|
       k,v = l.split(': ')
       if SRVR_NUMERIC_KEYS.include?(k)

--- a/lib/checkers/zookeeper_health_checker.rb
+++ b/lib/checkers/zookeeper_health_checker.rb
@@ -39,6 +39,12 @@ class ZookeeperHealthChecker
 
     check_details = parse_srvr_data(srvr_data)
 
+    # failed to parse the zk reponse so it might be still starting up
+    if check_details.nil?
+      @check_details = {'available' => false, 'monit_should_restart' => false}
+      return false
+    end
+
     check_details['over_outstanding_threshold'] = check_details['Outstanding'] > zk_outstanding_threshold
     check_details['leader'] = ['leader', 'standalone'].include?(check_details['Mode'])
     check_details['ruok'] = ruok_data[0]
@@ -67,6 +73,7 @@ class ZookeeperHealthChecker
 
     data.each do |l|
       k,v = l.split(': ')
+      next if v.nil?
       if SRVR_NUMERIC_KEYS.include?(k)
         result[k] = v.to_i
       else
@@ -74,6 +81,7 @@ class ZookeeperHealthChecker
       end
     end
 
+    return nil if result.empty?
     result
   end
 

--- a/spec/app_zk_spec.rb
+++ b/spec/app_zk_spec.rb
@@ -62,6 +62,13 @@ describe 'Zookeeper health check' do
     expect(last_response.status).to be(503)
   end
 
+  it 'should be marked down if Zookeeper is not serving requests' do
+    Whazzup.set(:zk_outstanding_threshold, 10)
+    allow_any_instance_of(Socket).to receive(:read).and_return('This ZooKeeper instance is not currently serving requests')
+    get '/zk'
+    expect(last_response.status).to be(503)
+  end
+
   it 'should be marked down if the connect to Zookeeper is refused' do
     allow_any_instance_of(Socket).to receive(:connect_nonblock).and_raise(Errno::ECONNREFUSED, 'mocking connection failure')
     get '/zk'


### PR DESCRIPTION
Fixes uncaught exception when zk returned `This ZooKeeper instance is not currently serving requests`