### PR TITLE
Disabling access log generation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -12,10 +12,6 @@ module Sinatra
         logger.level = ::Logger::INFO
         app.set :check_logger, logger
 
-        access_logger = ::Logger.new('log/access.log')
-        access_logger.level = ::Logger::INFO
-        app.use ::Rack::CommonLogger, access_logger
-
         error_logger = ::File.new(::File.join('log', 'error.log'), 'a+')
         error_logger.sync = true
         app.set :error_logger, error_logger


### PR DESCRIPTION
Since health checks are expected to come into whazzup at a high velocity,
generating access logs for every check is overkill. The existing statsd
monitoring is sufficent to see the health of the service.