### PR TITLE
Implement active health check against Zookeeper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,7 @@ end
 group :xdb do
   gem 'mysql2', '~> 0.3.16'
 end
+
+group :zk do
+  gem 'zk'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,10 @@ GEM
     json (1.8.2)
     launchy (2.4.3)
       addressable (~> 2.3)
+    little-plugger (1.1.3)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
     method_source (0.8.2)
     minitest (5.5.1)
     multi_json (1.10.1)
@@ -105,6 +109,10 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     websocket (1.2.1)
+    zk (1.9.5)
+      logging (~> 1.8.2)
+      zookeeper (~> 1.4.0)
+    zookeeper (1.4.10)
 
 PLATFORMS
   ruby
@@ -123,3 +131,4 @@ DEPENDENCIES
   sinatra (~> 1.4.5)
   timecop
   travis
+  zk

--- a/app.rb
+++ b/app.rb
@@ -42,7 +42,13 @@ class Whazzup < Sinatra::Base
 
   def initialize
     super
+    initialize_statsd
     initialize_checkers
+  end
+
+  def initialize_statsd
+    Statsd.logger = settings.check_logger
+    Whazzup.set :statsd, statsd
   end
 
   def initialize_checkers

--- a/app.rb
+++ b/app.rb
@@ -63,6 +63,7 @@ class Whazzup < Sinatra::Base
       settings.checkers[service] = HealthChecker.new(
         service_checker: service_checker,
         max_staleness: settings.max_staleness,
+        check_interval: settings.check_interval,
         logger: settings.check_logger,
         statsd: statsd,
         service: service

--- a/config.rb
+++ b/config.rb
@@ -19,6 +19,7 @@ module Sinatra
         app.set :checkers, {}
 
         app.set :max_staleness, 10
+        app.set :check_interval, 1
 
         app.set :statsd_host, '127.0.0.1'
         app.set :statsd_port, 8125
@@ -75,7 +76,7 @@ module Sinatra
         config = YAML.load_file ENV['WHAZZUP_CONFIG']
         app.set :services, config['services'].map(&:to_sym)
 
-        puts app.settings
+        app.set :check_interval, config['check_interval'].to_i if config['check_interval']
 
         if config['connection_settings']
           app.set :connection_settings, {

--- a/lib/checkers/health_checker.rb
+++ b/lib/checkers/health_checker.rb
@@ -14,7 +14,7 @@ class HealthChecker
     self.logger = settings[:logger] || Logger.new('/dev/null')
     self.statsd = settings[:statsd]
 
-    @check_interval = 1 # second
+    @check_interval = settings[:check_interval] || 1
 
     @last_check_time = nil
     @last_check_results = nil

--- a/lib/checkers/zookeeper_health_checker.rb
+++ b/lib/checkers/zookeeper_health_checker.rb
@@ -84,7 +84,8 @@ class ZookeeperHealthChecker
   end
 
   def zk_client
-    @zk_client ||= ZK.new("#{zk_connection_settings[:host]}:#{zk_connection_settings[:port]}/whazzup")
+    @zk_client ||= ZK.new("#{zk_connection_settings[:host]}:#{zk_connection_settings[:port]}/whazzup",
+                          timeout: zk_connection_settings[:timeout])
   end
 
   def parse_srvr_data(data)

--- a/spec/checkers/zookeeper_health_checker_spec.rb
+++ b/spec/checkers/zookeeper_health_checker_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+require 'app'
+require 'checkers/zookeeper_health_checker'
+
+describe ZookeeperHealthChecker do
+  let(:settings) { Whazzup.new.settings }
+  let(:checker) { ZookeeperHealthChecker.new(settings) }
+
+  it 'returns true if all the health checks pass' do
+    expect(checker.check).to eq(true)
+  end
+
+  it 'returns false if srvr command fails' do
+    expect(checker).to receive(:get_zk_data).with('srvr').and_return(nil)
+    expect(checker).to receive(:get_zk_data).with('ruok').and_call_original
+
+    expect(checker.check).to eq(false)
+  end
+
+  it 'returns false if ruok command fails' do
+    expect(checker).to receive(:get_zk_data).with('srvr').and_call_original
+    expect(checker).to receive(:get_zk_data).with('ruok').and_return(nil)
+
+    expect(checker.check).to eq(false)
+  end
+
+  it 'returns false if active health check throws an error creating node' do
+    mock_zk_client = double('zk_client')
+    expect(checker).to receive(:zk_client).and_return(mock_zk_client)
+    expect(mock_zk_client).to receive(:create).and_raise(ZK::Exceptions::NoNode)
+
+    expect(checker.check).to eq(false)
+  end
+
+  it 'returns false if active health check times out' do
+    mock_zk_client = double('zk_client')
+    expect(checker).to receive(:zk_client).and_return(mock_zk_client)
+    expect(mock_zk_client).to receive(:create).and_raise(Zookeeper::Exceptions::ContinuationTimeoutError)
+
+    expect(checker.check).to eq(false)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV['RACK_ENV'] = 'test'
+
 require 'rspec'
 
 require 'timecop'


### PR DESCRIPTION
This PR adds an active health check mechanism to the Zookeeper health checker. On each check interval, whazzup will create a sequential ephemeral node and then immediately delete that node. Any failure in that test will mark the service down.

statsd timing metrics are collected for that active health check, which will be a good source of data for the latency of the ZK cluster independent of the latency of any client application.

Since this active health check will add addidtional load to the cluster, the health check interval is now configurable so we can slowly ramp up traffic on a given cluster.